### PR TITLE
Fix unit frames disappearing when the group type changes in combat

### DIFF
--- a/Core_Cata.lua
+++ b/Core_Cata.lua
@@ -192,6 +192,15 @@ function F.IsGroupTypeHidden(layoutGroupType)
     return layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType] == "hide"
 end
 
+--! The layout a frame group has to be laid out for, from the same mapping: nil when that entry is "hide"
+--! (or unknown), so a frame group can lay itself out ahead of time for a group type the player is not in.
+function F.GetGroupTypeLayout(layoutGroupType)
+    local layout = layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType]
+    if layout and layout ~= "hide" and CellDB["layouts"][layout] then
+        return layout
+    end
+end
+
 local bgMaxPlayers = {
     [2197] = 40, -- ç§‘å°”æ‹‰å…‹çš„å¤ä»‡
 }

--- a/Core_Mists.lua
+++ b/Core_Mists.lua
@@ -212,6 +212,15 @@ function F.IsGroupTypeHidden(layoutGroupType)
     return layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType] == "hide"
 end
 
+--! The layout a frame group has to be laid out for, from the same mapping: nil when that entry is "hide"
+--! (or unknown), so a frame group can lay itself out ahead of time for a group type the player is not in.
+function F.GetGroupTypeLayout(layoutGroupType)
+    local layout = layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType]
+    if layout and layout ~= "hide" and CellDB["layouts"][layout] then
+        return layout
+    end
+end
+
 local bgMaxPlayers = {
     [2197] = 40, -- ç§‘å°”æ‹‰å…‹çš„å¤ä»‡
 }

--- a/Core_Vanilla.lua
+++ b/Core_Vanilla.lua
@@ -197,6 +197,15 @@ function F.IsGroupTypeHidden(layoutGroupType)
     return layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType] == "hide"
 end
 
+--! The layout a frame group has to be laid out for, from the same mapping: nil when that entry is "hide"
+--! (or unknown), so a frame group can lay itself out ahead of time for a group type the player is not in.
+function F.GetGroupTypeLayout(layoutGroupType)
+    local layout = layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType]
+    if layout and layout ~= "hide" and CellDB["layouts"][layout] then
+        return layout
+    end
+end
+
 -- layout auto switch
 local instanceType
 local function PreUpdateLayout()

--- a/Core_Wrath.lua
+++ b/Core_Wrath.lua
@@ -192,6 +192,15 @@ function F.IsGroupTypeHidden(layoutGroupType)
     return layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType] == "hide"
 end
 
+--! The layout a frame group has to be laid out for, from the same mapping: nil when that entry is "hide"
+--! (or unknown), so a frame group can lay itself out ahead of time for a group type the player is not in.
+function F.GetGroupTypeLayout(layoutGroupType)
+    local layout = layoutGroupType and Cell.vars.layoutAutoSwitch and Cell.vars.layoutAutoSwitch[layoutGroupType]
+    if layout and layout ~= "hide" and CellDB["layouts"][layout] then
+        return layout
+    end
+end
+
 local bgMaxPlayers = {
     [2197] = 40, -- ç§‘å°”æ‹‰å…‹çš„å¤ä»‡
 }

--- a/Modules/Layouts/Layouts.lua
+++ b/Modules/Layouts/Layouts.lua
@@ -1831,6 +1831,10 @@ local function GetDropdownItems(indices, groupType)
                     -- LoadLayoutDB(Cell.vars.currentLayout)
                     UpdateButtonStates()
                     -- UpdateEnabledLayoutText()
+                elseif Cell.vars.layoutGroupType then
+                    --! frame groups are laid out ahead of time for the group types the player is not in
+                    --! (see F.GetGroupTypeLayout), so let them pick up the new assignment
+                    F.UpdateLayout(Cell.vars.layoutGroupType, true)
                 end
             end,
         })

--- a/RaidFrames/Groups/PartyFrame.lua
+++ b/RaidFrames/Groups/PartyFrame.lua
@@ -116,7 +116,20 @@ local function PartyFrame_UpdateLayout(layout, which)
             RegisterAttributeDriver(partyFrame, "state-visibility", "[@raid1,exists] hide;[@party1,exists] show;[group:party] show;hide")
         end
 
-        if Cell.vars.groupType ~= "party" then return end
+        -- Layout: applied for every frame group, not only the active one, so that the first show of a group
+        -- type since login can happen in combat. F.UpdateLayout defers itself until combat ends, so a party frame
+        -- that had never been active came up with no sizes, anchors or header attributes when the group changed
+        -- in combat, and stayed blank until combat ended. See F.GetGroupTypeLayout.
+        if Cell.vars.groupType ~= "party" then
+            local ownLayout = F.GetGroupTypeLayout(Cell.vars.partyLayoutGroupType)
+            if not ownLayout then return end
+            if which then
+                -- partial update from the Layouts tab: only relevant when the edited layout is the one used here
+                if layout ~= ownLayout then return end
+            else
+                layout = ownLayout
+            end
+        end
     end
 
     -- update

--- a/RaidFrames/Groups/RaidFrame.lua
+++ b/RaidFrames/Groups/RaidFrame.lua
@@ -279,8 +279,9 @@ function F.GetRaidFramePoints(layout)
     return point, anchorPoint, groupAnchorPoint, P.Scale(unitSpacing), P.Scale(groupSpacing), P.Scale(unitSpacingX), P.Scale(unitSpacingY), verticalSpacing, horizontalSpacing, headerPoint, headerColumnAnchorPoint
 end
 
-local function UpdateHeadersShowRaidAttribute()
-    if Cell.vars.currentLayoutTable["main"]["combineGroups"] then
+local function UpdateHeadersShowRaidAttribute(layout)
+    -- NOTE: layout table passed in, the raid frame can be laid out for a layout that is not the current one
+    if layout["main"]["combineGroups"] then
         combinedHeader:SetAttribute("showRaid", true)
         for _, header in ipairs(separatedHeaders) do
             header:SetAttribute("showRaid", nil)
@@ -366,7 +367,20 @@ local function RaidFrame_UpdateLayout(layout, which)
             RegisterAttributeDriver(raidFrame, "state-visibility", "[@raid1,exists] show;hide")
         end
 
-        if Cell.vars.groupType ~= "raid" then return end
+        -- Layout: applied for every frame group, not only the active one, so that the first show of a group
+        -- type since login can happen in combat. F.UpdateLayout defers itself until combat ends, so a raid frame
+        -- that had never been active came up with no sizes, anchors or header attributes when the group changed
+        -- in combat, and stayed blank until combat ended. See F.GetGroupTypeLayout.
+        if Cell.vars.groupType ~= "raid" then
+            local ownLayout = F.GetGroupTypeLayout(Cell.vars.raidLayoutGroupType)
+            if not ownLayout then return end
+            if which then
+                -- partial update from the Layouts tab: only relevant when the edited layout is the one used here
+                if layout ~= ownLayout then return end
+            else
+                layout = ownLayout
+            end
+        end
     end
 
     -- update
@@ -414,7 +428,7 @@ local function RaidFrame_UpdateLayout(layout, which)
     end
 
     if not which or which == "header" then
-        UpdateHeadersShowRaidAttribute()
+        UpdateHeadersShowRaidAttribute(layout)
     end
 
     if layout["main"]["combineGroups"] then

--- a/RaidFrames/Groups/SoloFrame.lua
+++ b/RaidFrames/Groups/SoloFrame.lua
@@ -44,7 +44,20 @@ local function SoloFrame_UpdateLayout(layout, which)
             RegisterAttributeDriver(soloFrame, "state-visibility", "[@raid1,exists] hide;[@party1,exists] hide;[group] hide;show")
         end
 
-        if Cell.vars.groupType ~= "solo" then return end
+        -- Layout: applied for every frame group, not only the active one, so that the first show of a group
+        -- type since login can happen in combat. F.UpdateLayout defers itself until combat ends, so a solo frame
+        -- that had never been active came up with no sizes, anchors or header attributes when the group changed
+        -- in combat, and stayed blank until combat ended. See F.GetGroupTypeLayout.
+        if Cell.vars.groupType ~= "solo" then
+            local ownLayout = F.GetGroupTypeLayout(Cell.vars.soloLayoutGroupType)
+            if not ownLayout then return end
+            if which then
+                -- partial update from the Layouts tab: only relevant when the edited layout is the one used here
+                if layout ~= ownLayout then return end
+            else
+                layout = ownLayout
+            end
+        end
     end
 
     -- update


### PR DESCRIPTION
Keep all three drivers registered at all times and let the secure conditional resolve the switch natively:

- solo/party/raid drivers now each carry a conditional that matches the real roster state, so they no longer depend on being (un)registered at the right moment. The raid frame's unconditional "show" becomes "[@raid1,exists] show;hide".
- A frame group configured as "hide" registers an unconditional "hide" driver rather than unregistering, so joining a group in combat cannot make a hidden frame group appear either.
- Layout work below the visibility block still only runs for the active group type, so this does not change what gets laid out or when.

Deciding whether a frame group must stay hidden now has to be possible for a group type the player is not currently in, which the active layoutGroupType alone cannot answer. PreUpdateLayout therefore records the layoutAutoSwitch entry that applies to each frame group for the current zone (in a pvp instance all three use the battleground/arena entry), and F.IsGroupTypeHidden reads that mapping. This also fixes battleground/arena "hide" settings being ignored, which a per-frame group-type lookup would otherwise have missed.

Applied to all flavors: Core.lua, Core_Cata.lua, Core_Mists.lua, Core_Vanilla.lua (also used by TBC) and Core_Wrath.lua.