### PR TITLE
Fix dispel border toggles breaking the debuffs and dispels indicators

### DIFF
--- a/RaidFrames/UnitButton_Cata_Wrath.lua
+++ b/RaidFrames/UnitButton_Cata_Wrath.lua
@@ -228,12 +228,26 @@ local function HandleIndicators(b)
                 P.Size(indicator, t["size"][1], t["size"][2])
             end
         end
-        -- update thickness
+        -- update thickness (+ dispel border on/off for debuffs, "off" = 0 thickness)
+        --! same as retail UnitButton.lua: without this the dispel-type border came back on every time the
+        --! indicators were (re)created - first group after a reload, layout switch - whatever the setting.
         if t["thickness"] then
-            indicator:SetThickness(t["thickness"])
+            if t["indicatorName"] == "debuffs" then
+                if indicator.SetBorder then
+                    local on = t["showDispelBorder"] ~= false
+                    indicator:SetBorder(on and t["thickness"] or 0)
+                end
+            elseif t["indicatorName"] == "dispels" then
+                if indicator.SetFrameBorderThickness then
+                    indicator:SetFrameBorderThickness(t["thickness"])
+                    indicator:SetFrameBorderEnabled(t["showDispelFrameBorder"] == true)
+                end
+            else
+                indicator:SetThickness(t["thickness"])
+            end
         end
         -- update border
-        if t["border"] then
+        if t["border"] and indicator.SetBorder then
             indicator:SetBorder(t["border"])
         end
         -- update height

--- a/RaidFrames/UnitButton_Mists.lua
+++ b/RaidFrames/UnitButton_Mists.lua
@@ -249,12 +249,26 @@ local function HandleIndicators(b)
                 P.Size(indicator, t["size"][1], t["size"][2])
             end
         end
-        -- update thickness
+        -- update thickness (+ dispel border on/off for debuffs, "off" = 0 thickness)
+        --! same as retail UnitButton.lua: without this the dispel-type border came back on every time the
+        --! indicators were (re)created - first group after a reload, layout switch - whatever the setting.
         if t["thickness"] then
-            indicator:SetThickness(t["thickness"])
+            if t["indicatorName"] == "debuffs" then
+                if indicator.SetBorder then
+                    local on = t["showDispelBorder"] ~= false
+                    indicator:SetBorder(on and t["thickness"] or 0)
+                end
+            elseif t["indicatorName"] == "dispels" then
+                if indicator.SetFrameBorderThickness then
+                    indicator:SetFrameBorderThickness(t["thickness"])
+                    indicator:SetFrameBorderEnabled(t["showDispelFrameBorder"] == true)
+                end
+            else
+                indicator:SetThickness(t["thickness"])
+            end
         end
         -- update border
-        if t["border"] then
+        if t["border"] and indicator.SetBorder then
             indicator:SetBorder(t["border"])
         end
         -- update height

--- a/RaidFrames/UnitButton_Vanilla.lua
+++ b/RaidFrames/UnitButton_Vanilla.lua
@@ -214,12 +214,26 @@ local function HandleIndicators(b)
                 P.Size(indicator, t["size"][1], t["size"][2])
             end
         end
-        -- update thickness
+        -- update thickness (+ dispel border on/off for debuffs, "off" = 0 thickness)
+        --! same as retail UnitButton.lua: without this the dispel-type border came back on every time the
+        --! indicators were (re)created - first group after a reload, layout switch - whatever the setting.
         if t["thickness"] then
-            indicator:SetThickness(t["thickness"])
+            if t["indicatorName"] == "debuffs" then
+                if indicator.SetBorder then
+                    local on = t["showDispelBorder"] ~= false
+                    indicator:SetBorder(on and t["thickness"] or 0)
+                end
+            elseif t["indicatorName"] == "dispels" then
+                if indicator.SetFrameBorderThickness then
+                    indicator:SetFrameBorderThickness(t["thickness"])
+                    indicator:SetFrameBorderEnabled(t["showDispelFrameBorder"] == true)
+                end
+            else
+                indicator:SetThickness(t["thickness"])
+            end
         end
         -- update border
-        if t["border"] then
+        if t["border"] and indicator.SetBorder then
             indicator:SetBorder(t["border"])
         end
         -- update height


### PR DESCRIPTION
The "Show dispel-type border" (debuffs) and "Show frame border" (dispels) checkbuttons fire UpdateIndicators with setting == "checkbutton", but neither UnitButton_*.lua's UpdateIndicators had a branch for them, so both fell through to the catch-all:

    indicatorBooleans[indicatorName] = value2

For debuffs that clobbers the dispellableByMe filter, so ticking the box silently hid every debuff the player cannot dispel. For dispels it is worse: indicatorBooleans["dispels"] holds the filter *table*, so replacing it with a boolean makes the next aura update error out on indicatorBooleans["dispels"]["dispellableByMe"] and the whole indicator stops working. Neither toggle actually reached the border it names.

Handle both explicitly instead:

- showDispelBorder re-applies the icon border thickness (0 when off), which takes effect immediately on the existing icons.
- showDispelFrameBorder flips the dispels frame-border flag and forces an aura update, since the border strips are only colored and shown from SetDispels -- turning the toggle back on would otherwise do nothing visible until the unit's auras next changed.

Applied to all flavors: UnitButton.lua, UnitButton_Cata_Wrath.lua, UnitButton_Mists.lua and UnitButton_Vanilla.lua (also used by TBC).