### PR TITLE
Fix release builds producing a broken package

### DIFF
--- a/.release/release.sh
+++ b/.release/release.sh
@@ -193,7 +193,7 @@ toc_to_type() {
 	case $toc_version in
 		11???) game_type="classic" ;;
 		20???) game_type="bcc" ;;
-		30???) game_type="wrath" ;;
+		30???|38???) game_type="wrath" ;; # 38xxx: Wrath Classic Anniversary realms
 		40???) game_type="cata" ;;
 		50???) game_type="mists" ;;
 		*) game_type="retail"

--- a/Modules/RaidDebuffs/RaidDebuffs.lua
+++ b/Modules/RaidDebuffs/RaidDebuffs.lua
@@ -41,10 +41,10 @@ local encounterJournalList = {
     --     },
     -- },
 }
---[==[@debug@
+--@debug@
 Cell_DevExpansionData = encounterJournalList
 Cell_DevExpansionNames = {}
---@end-debug@]==]
+--@end-debug@
 
 -- used to GetInstanceInfo/GetRealZoneText --> instanceId
 local instanceNameMapping = {
@@ -116,9 +116,9 @@ local function LoadList()
     for tier = 1, num do
         local name = EJ_GetTierInfo(tier)
         encounterJournalList[name] = {}
-        --[==[@debug@
+        --@debug@
         tinsert(Cell_DevExpansionNames, 1, name)
-        --@end-debug@]==]
+        --@end-debug@
 
         if tier ~= CURRENT_SEASON_INDEX then -- don't load raid for "Current Season"
             LoadInstanceList(tier, "raid", encounterJournalList[name])

--- a/RaidFrames/MainFrame.lua
+++ b/RaidFrames/MainFrame.lua
@@ -179,7 +179,7 @@ P.Point(loadingBar, "BOTTOMRIGHT", options, -1, 1)
 -------------------------------------------------
 -- MemoryUsage
 -------------------------------------------------
---[==[@debug@
+--@debug@
 -- local memUsage = CreateFrame("Frame", nil, cellMainFrame)
 -- memUsage:SetSize(10, 10)
 -- memUsage:SetPoint("LEFT", raid, "RIGHT", 5, 0)
@@ -193,7 +193,7 @@ P.Point(loadingBar, "BOTTOMRIGHT", options, -1, 1)
 --         self.elapsed = 0
 --     end
 -- end)
---@end-debug@]==]
+--@end-debug@
 
 -------------------------------------------------
 -- fadeIn & fadeOut


### PR DESCRIPTION
Two problems that only show up in a packaged (tagged) build, not in a source checkout:

1. Double-wrapped debug blocks.

   release.sh's lua_filter comments out debug-only code in a release build by rewriting "--@debug@" to "--[==[@debug@" and "--@end-debug@" to "--@end-debug@]==]". Three blocks already carried the *packaged* form in the source, so the closing rewrite matched again and appended a second bracket:

       --@end-debug@]==]  ->  --@end-debug@]==]]==]

   That is a syntax error. RaidFrames/MainFrame.lua then failed to load, Cell.unitButtons was never created, and every consumer of it threw "attempt to index field 'unitButtons' (a nil value)" -- no unit frames, options frame at the wrong scale, tabs that never rendered.

   Restore the un-packaged source form in RaidFrames/MainFrame.lua and Modules/RaidDebuffs/RaidDebuffs.lua so the filter emits valid output. lua_filter debug only runs for release builds, which is why a source checkout never showed this.

2. Interface 38xxx was packaged as retail.

   Cell_Wrath.toc declares "## Interface: 38001", which toc_to_type did not recognise, so it fell through to the retail game type. Map 38xxx to wrath alongside 30xxx.

Verified by running luac -p over the packaged output rather than the source: 160/160 Lua files in the built package compile, and the only remaining source-vs-package difference is the packager's intended single wrapping.